### PR TITLE
fix: fix mAPI Post status code transform

### DIFF
--- a/src/main/java/io/gravitee/policy/status/code/StatusCodePolicy.java
+++ b/src/main/java/io/gravitee/policy/status/code/StatusCodePolicy.java
@@ -58,9 +58,4 @@ public class StatusCodePolicy implements Policy {
             }
         });
     }
-
-    @Override
-    public Completable onMessageResponse(MessageExecutionContext ctx) {
-        return doOnResponse(ctx);
-    }
 }

--- a/src/main/resources/plugin.properties
+++ b/src/main/resources/plugin.properties
@@ -7,4 +7,3 @@ type=policy
 category=transformation
 icon=http-status-code.svg
 proxy=RESPONSE
-message=RESPONSE

--- a/src/test/java/io/gravitee/policy/status/code/StatusCodePolicyTest.java
+++ b/src/test/java/io/gravitee/policy/status/code/StatusCodePolicyTest.java
@@ -113,24 +113,6 @@ class StatusCodePolicyTest {
     }
 
     @Test
-    void shouldChangeStatusInMessageResponse() {
-        StatusMapping mapping = new StatusMapping();
-        mapping.setInputStatusCode(200);
-        mapping.setOutputStatusCode(404);
-        configuration.setStatusMappings(List.of(mapping));
-
-        MessageExecutionContext messageContext = Mockito.mock(MessageExecutionContext.class);
-        Response response = Mockito.mock(Response.class);
-        when(messageContext.response()).thenReturn(response);
-        when(response.status()).thenReturn(200);
-
-        Completable completable = policy.onMessageResponse(messageContext);
-        completable.test().assertComplete();
-
-        verify(response).status(404);
-    }
-
-    @Test
     void shouldNotChangeStatusWhenMappingsListIsEmpty() {
         configuration.setStatusMappings(List.of());
 
@@ -321,19 +303,6 @@ class StatusCodePolicyTest {
 
         verify(response).status(201);
         assertEquals("application/json", response.headers().getFirst("Content-Type"));
-    }
-
-    @Test
-    void shouldHandleMessageResponseWithoutStatusCode() {
-        MessageExecutionContext messageContext = Mockito.mock(MessageExecutionContext.class);
-        Response response = Mockito.mock(Response.class);
-        when(messageContext.response()).thenReturn(response);
-        when(response.status()).thenReturn(-1);
-
-        Completable completable = policy.onMessageResponse(messageContext);
-        completable.test().assertComplete();
-
-        verify(response, never()).status(anyInt());
     }
 
     @Test


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-7731

## Description


Steps to reproduce:

Create a V4 message API with Get and Post entrypoints and Kafka endpoint

Apply Status Transformation Policy on response 

Configure the policy to transform 200 status and 202 into another value 

Send a Get request and a Post request

Check if the statuses were transformed as configured in the policy

<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.0.1-APIM-7731-fix-mAPI-POST-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-transform-status-code/1.0.1-APIM-7731-fix-mAPI-POST-SNAPSHOT/gravitee-policy-transform-status-code-1.0.1-APIM-7731-fix-mAPI-POST-SNAPSHOT.zip)
  <!-- Version placeholder end -->
